### PR TITLE
remove unique index from IDToken's token field

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,4 @@ pySilver
 Rodney Richardson
 Silvano Cerza
 Stéphane Raimbault
+Michael Helvey

--- a/oauth2_provider/migrations/0004_idtoken.py
+++ b/oauth2_provider/migrations/0004_idtoken.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             name='IDToken',
             fields=[
                 ('id', models.BigAutoField(primary_key=True, serialize=False)),
-                ('token', models.TextField(unique=True)),
+                ('token', models.TextField()),
                 ('expires', models.DateTimeField()),
                 ('scope', models.TextField(blank=True)),
                 ('created', models.DateTimeField(auto_now_add=True)),

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -449,7 +449,7 @@ class AbstractIDToken(models.Model):
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE, blank=True, null=True,
         related_name="%(app_label)s_%(class)s"
     )
-    token = models.TextField(unique=True)
+    token = models.TextField()
     application = models.ForeignKey(
         oauth2_settings.APPLICATION_MODEL, on_delete=models.CASCADE, blank=True, null=True,
     )


### PR DESCRIPTION
## Description of the Change

On MySQL 8.0 (and before, as far as I know) creating a unique TEXT index
will fail with err 1170 "BLOB/TEXT column 'token' used in key specification
without a key length"

This PR simply removes the invalid unique index.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [X] PR only contains one change (considered splitting up PR)
- [ ] unit-test added (N/A for this change as far as I know)
- [ ] documentation updated (N/A for this change as far as I know)
- [ ] `CHANGELOG.md` updated (only for user relevant changes) 
- [X] author name in `AUTHORS`
